### PR TITLE
add required NSLocationWhenInUseUsageDescription

### DIFF
--- a/PrideFestival/Info.plist
+++ b/PrideFestival/Info.plist
@@ -33,8 +33,10 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>We need your location to help you navigate the festival.</string>
+  <key>NSLocationWhenInUseUsageDescription</key>
+  <string>We need your location to help you navigate the festival.</string>
+  <key>NSLocationAlwaysUsageDescription</key>
+  <string>We need your location to help you navigate the festival.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Looks like Apple is now requiring this property even if we only ask for when-in-use location permission.